### PR TITLE
chore: bump tools for Go 1.15.7 update

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.3.0-12-g0eb84c1
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.3.0-19-ge54841a
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.3.0-50-g18423fa
+  PKGS_VERSION: v0.3.0-68-g72c4450
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
See talos-systems/tools#121

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>