### PR TITLE
chore: use 0.5.0 tagged images of pkgs and tools

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0-alpha.0-4-g1f26def
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.5.0
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.5.0-alpha.0-5-g9a6cf6b
+  PKGS_VERSION: v0.5.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
No changes, just tag updates.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>