### PR TITLE
chore: update pkgs to use CNI plugins v0.9.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0-2-g7172a5d
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.7.0-alpha.0-3-gb6fca88
+  PKGS_VERSION: v0.7.0-alpha.0-6-g65159fb
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
See https://github.com/talos-systems/pkgs/pull/304.

Signed-off-by: Alexey Palazhchenko <alexey.palazhchenko@gmail.com>