### PR TITLE
chore: bump tools and packages for Go 1.16.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0-2-g7172a5d
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.7.0-alpha.0-3-g2368154
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.7.0-alpha.0-6-g65159fb
+  PKGS_VERSION: v0.7.0-alpha.0-16-gda4ac04
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
See https://github.com/talos-systems/pkgs/pull/319

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>