### PR TITLE
chore: update pkgs and tools

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0-3-g2790b55
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.8.0-alpha.0
+  PKGS_VERSION: v0.8.0-alpha.0-3-gdb90f93
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
To use Go 1.17.1.
