### PR TITLE
chore: use tagged versions tools and pkgs 0.8.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,9 +3,9 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0-alpha.0-3-g2790b55
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.8.0
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.8.0-alpha.0-3-gdb90f93
+  PKGS_VERSION: v0.8.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras


### PR DESCRIPTION
This prepares for Talos 0.13 release.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>