### PR TITLE
feat: include flannel CNI plugin into install-cni package

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@ format: v1alpha2
 vars:
   TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.9.0-alpha.0-5-g96e0231
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.9.0-alpha.0-11-g4f0f238
+  PKGS_VERSION: v0.9.0-alpha.0-22-g80a5f97
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras

--- a/install-cni/pkg.yaml
+++ b/install-cni/pkg.yaml
@@ -2,6 +2,7 @@ name: install-cni
 variant: alpine
 dependencies:
   - image: "{{ .PKGS_PREFIX }}/cni:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/flannel-cni:{{ .PKGS_VERSION }}"
 steps:
   - install:
       - |


### PR DESCRIPTION
With changes in https://github.com/talos-systems/pkgs/pull/363, flannel
CNI plugin is now coming from a separate package.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>