### PR TITLE
chore: reproducible builds, use pkgs base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 
 BUILD := docker buildx build
 PLATFORM ?= linux/amd64,linux/arm64
@@ -12,6 +13,7 @@ PUSH ?= false
 COMMON_ARGS := --file=Pkgfile
 COMMON_ARGS += --progress=$(PROGRESS)
 COMMON_ARGS += --platform=$(PLATFORM)
+COMMON_ARGS += --build-arg=SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH)
 
 , := ,
 empty :=

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,11 +1,10 @@
-# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.3-frontend
+# syntax = ghcr.io/talos-systems/bldr:v0.2.0-alpha.7-frontend
 
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-5-g8197edb
   PKGS_PREFIX: ghcr.io/talos-systems
-  PKGS_VERSION: v0.10.0-alpha.0-33-g9d61f59
+  PKGS_VERSION: v1.0.0
 
 labels:
   org.opencontainers.image.source: https://github.com/talos-systems/extras

--- a/base/pkg.yaml
+++ b/base/pkg.yaml
@@ -2,21 +2,8 @@ name: base
 variant: scratch
 shell: /toolchain/bin/bash
 dependencies:
-  - image: "{{ .TOOLS_IMAGE }}"
-  - image: "{{ .PKGS_PREFIX }}/musl:{{ .PKGS_VERSION }}"
+  - image: "{{ .PKGS_PREFIX }}/base:{{ .PKGS_VERSION }}"
   - image: "{{ .PKGS_PREFIX }}/ca-certificates:{{ .PKGS_VERSION }}"
-steps:
-  - prepare:
-      - |
-        cp -R /toolchain/lib/gcc /lib
-        cp -R /toolchain/lib/libgcc* /lib
-
-        mkdir /bin
-        ln -sv /toolchain/bin/bash /bin/bash
-        ln -sv /toolchain/bin/bash /bin/sh
-        ln -sv /toolchain/bin/pwd /bin/pwd
-
-        adjust.sh
 finalize:
   - from: /
     to: /


### PR DESCRIPTION
* use `bldr` with support for `SOURCE_DATE_EPOCH`
* use `base` from `pkgs` as our build base
* remove dependency on `tools`, as `base` includes `tools`

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>